### PR TITLE
FIX :: FormProvider랑 useFormContext 활용하기

### DIFF
--- a/app/components/Field.tsx
+++ b/app/components/Field.tsx
@@ -1,14 +1,12 @@
-import { useContext } from "react";
 import { Item } from "../types/item.type";
-import Group from "./Group";
-import { RegisterContext } from "./Step";
+import {useFormContext} from "react-hook-form";
 
 interface Props {
   item: Item;
 }
 const Field = ({ item }: Props) => {
   const { title, value, placeholder } = item;
-  const register = useContext(RegisterContext)!;
+  const { register } = useFormContext();
 
   return (
     <div>

--- a/app/components/Group.tsx
+++ b/app/components/Group.tsx
@@ -1,4 +1,3 @@
-import { UseFormRegister, FieldValues } from "react-hook-form";
 import { Item } from "../types/item.type";
 import Field from "./Field";
 

--- a/app/components/Step.tsx
+++ b/app/components/Step.tsx
@@ -1,18 +1,15 @@
-import { createContext, useState } from "react";
 import { Item } from "../types/item.type";
 import Group from "./Group";
-import { useForm, FieldValues, type UseFormRegister } from "react-hook-form";
+import {useForm, FormProvider} from "react-hook-form";
 import { Form, useSubmit } from "@remix-run/react";
 
 interface Props {
   item: Item;
 }
-export const RegisterContext =
-  createContext<UseFormRegister<FieldValues> | null>(null);
 
 const Step = ({ item }: Props) => {
   const submit = useSubmit();
-  const { handleSubmit, register } = useForm();
+  const methods = useForm();
 
   const onSubmit = (data: Object) => {
     console.log("client");
@@ -23,17 +20,15 @@ const Step = ({ item }: Props) => {
   };
 
   return (
-    <RegisterContext.Provider value={register}>
-      <div>
+    <FormProvider {...methods}>
         <h1>{item.title}</h1>
-        <Form onSubmit={handleSubmit(onSubmit)}>
+        <Form onSubmit={methods.handleSubmit(onSubmit)}>
           {item.childrenItemList?.map((groupItem) => (
             <Group key={groupItem.title} item={groupItem} />
           ))}
           <button type="submit">제출</button>
         </Form>
-      </div>
-    </RegisterContext.Provider>
+    </FormProvider>
   );
 };
 


### PR DESCRIPTION
Context 따로 만들 필요 없이 react-hook-form의 useFormContext와 FormProvider를 활용할 수 있어요